### PR TITLE
fix(js-custom-tab): revert back original splide classes

### DIFF
--- a/examples/js-custom-tab/package-lock.json
+++ b/examples/js-custom-tab/package-lock.json
@@ -8,10 +8,10 @@
       "name": "composition",
       "version": "0.1.0",
       "dependencies": {
+        "@splidejs/splide": "4.1.4",
         "@uploadcare/file-uploader": "^1.2.0"
       },
       "devDependencies": {
-        "@splidejs/splide": "4.1.4",
         "postcss-import": "15.1.0",
         "vite": "4.5.2"
       }
@@ -371,8 +371,7 @@
     "node_modules/@splidejs/splide": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.1.4.tgz",
-      "integrity": "sha512-5I30evTJcAJQXt6vJ26g2xEkG+l1nXcpEw4xpKh0/FWQ8ozmAeTbtniVtVmz2sH1Es3vgfC4SS8B2X4o5JMptA==",
-      "dev": true
+      "integrity": "sha512-5I30evTJcAJQXt6vJ26g2xEkG+l1nXcpEw4xpKh0/FWQ8ozmAeTbtniVtVmz2sH1Es3vgfC4SS8B2X4o5JMptA=="
     },
     "node_modules/@symbiotejs/symbiote": {
       "version": "1.11.7",

--- a/examples/js-custom-tab/package.json
+++ b/examples/js-custom-tab/package.json
@@ -10,11 +10,11 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@splidejs/splide": "4.1.4",
     "postcss-import": "15.1.0",
     "vite": "4.5.2"
   },
   "dependencies": {
+    "@splidejs/splide": "4.1.4",
     "@uploadcare/file-uploader": "^1.2.0"
   }
 }

--- a/examples/js-custom-tab/src/UnsplashSource.js
+++ b/examples/js-custom-tab/src/UnsplashSource.js
@@ -130,9 +130,9 @@ export class UnsplashSource extends UploaderBlock {
       </button>
     </uc-activity-header>
     <div class="uc-content">
-      <div ref="slider" class="uc-splide">
-        <div class="uc-splide__track">
-          <ul class="uc-splide__list"></ul>
+      <div ref="slider" class="splide">
+        <div class="splide__track">
+          <ul class="splide__list"></ul>
         </div>
       </div>
     </div>

--- a/examples/js-custom-tab/src/unsplash-source.css
+++ b/examples/js-custom-tab/src/unsplash-source.css
@@ -46,22 +46,22 @@ uc-unsplash-source .uc-image-slider img {
   flex: 0 0 100%;
 }
 
-uc-unsplash-source .uc-splide {
+uc-unsplash-source .splide {
   width: 100%;
 }
 
-uc-unsplash-source .uc-splide__track {
+uc-unsplash-source .splide__track {
   height: 100%;
 }
 
-uc-unsplash-source .uc-splide__slide {
+uc-unsplash-source .splide__slide {
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
 }
 
-uc-unsplash-source .uc-splide__slide img {
+uc-unsplash-source .splide__slide img {
   height: 100%;
   object-fit: cover;
   flex: 0 1 100%;


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced image fetching from Unsplash, now displaying random images in the Splide slider.
	- Users can select the currently active image, adding its URL to their upload collection.
	- Improved slider functionality with automatic fetching of new images when items are low.

- **Chores**
	- Updated project dependencies, moving `@splidejs/splide` to core dependencies for better project structure.
	- Renamed CSS class selectors for the Splide image slider to ensure consistent styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->