### PR TITLE
Remove Discord link from README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,5 +18,5 @@ jobs:
         env:
           VITE_UNSPLASH_TOKEN: ${{ secrets.UNSPLASH_TOKEN }}
         run: |
-          npm run install-ci-deps
+          npm ci
           npm run build

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://uploadcare.com?ref=github-file-uploader-examples-readme">Website</a> • 
-  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-file-uploader-examples-readme">Quick Start</a> • 
-  <a href="https://uploadcare.com/docs?ref=github-file-uploader-examples-readme">Docs</a> • 
-  <a href="https://uploadcare.com/blog?ref=github-file-uploader-examples-readme">Blog</a> • 
-  <a href="https://discord.gg/mKWRgRsVz8?ref=github-file-uploader-examples-readme">Discord</a> •
+  <a href="https://uploadcare.com?ref=github-file-uploader-examples-readme">Website</a> •
+  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-file-uploader-examples-readme">Quick Start</a> •
+  <a href="https://uploadcare.com/docs?ref=github-file-uploader-examples-readme">Docs</a> •
+  <a href="https://uploadcare.com/blog?ref=github-file-uploader-examples-readme">Blog</a> •
   <a href="https://twitter.com/Uploadcare?ref=github-file-uploader-examples-readme">Twitter</a>
 </p>
 

--- a/examples/angular-uploader/README.md
+++ b/examples/angular-uploader/README.md
@@ -8,11 +8,10 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://uploadcare.com?ref=github-angular-example-readme">Website</a> • 
-  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-angular-example-readme">Quick Start</a> • 
-  <a href="https://uploadcare.com/docs?ref=github-angular-example-readme">Docs</a> • 
-  <a href="https://uploadcare.com/blog?ref=github-angular-example-readme">Blog</a> • 
-  <a href="https://discord.gg/mKWRgRsVz8?ref=github-angular-example-readme">Discord</a> •
+  <a href="https://uploadcare.com?ref=github-angular-example-readme">Website</a> •
+  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-angular-example-readme">Quick Start</a> •
+  <a href="https://uploadcare.com/docs?ref=github-angular-example-readme">Docs</a> •
+  <a href="https://uploadcare.com/blog?ref=github-angular-example-readme">Blog</a> •
   <a href="https://twitter.com/Uploadcare?ref=github-angular-example-readme">Twitter</a>
 </p>
 
@@ -52,14 +51,14 @@ Please, read the [File Uploader documentation](https://uploadcare.com/docs/file-
 ### Angular + Web Components
 
 File Uploader is native to the Web but not to Angular. However, Angular does everything to make solutions based on Web Components
-to work properly with it. 
+to work properly with it.
 
 To help Angular to figure out where you're using Web Components, you have to set
-`schemas` property of the file uploader component to `[CUSTOM_ELEMENTS_SCHEMA]`, where `CUSTOM_ELEMENTS_SCHEMA` 
+`schemas` property of the file uploader component to `[CUSTOM_ELEMENTS_SCHEMA]`, where `CUSTOM_ELEMENTS_SCHEMA`
 is a special schema imported from `@angular/core`.
 In this example we have done it inside every component. E.g. [the file-uploader component](./src/app/components/file-uploader/file-uploader.component.ts).
 
-You may like to read [custom element schemas](https://angular.dev/guide/components/advanced-configuration#custom-element-schemas) doc, 
+You may like to read [custom element schemas](https://angular.dev/guide/components/advanced-configuration#custom-element-schemas) doc,
 if you want to know more about using custom elements in Angular.
 
 ### Styling

--- a/examples/js-uploader/README.md
+++ b/examples/js-uploader/README.md
@@ -8,11 +8,10 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://uploadcare.com?ref=github-js-example-readme">Website</a> • 
-  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-js-example-readme">Quick Start</a> • 
-  <a href="https://uploadcare.com/docs?ref=github-js-example-readme">Docs</a> • 
-  <a href="https://uploadcare.com/blog?ref=github-js-example-readme">Blog</a> • 
-  <a href="https://discord.gg/mKWRgRsVz8?ref=github-js-example-readme">Discord</a> •
+  <a href="https://uploadcare.com?ref=github-js-example-readme">Website</a> •
+  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-js-example-readme">Quick Start</a> •
+  <a href="https://uploadcare.com/docs?ref=github-js-example-readme">Docs</a> •
+  <a href="https://uploadcare.com/blog?ref=github-js-example-readme">Blog</a> •
   <a href="https://twitter.com/Uploadcare?ref=github-js-example-readme">Twitter</a>
 </p>
 

--- a/examples/next-uploader-adapter/README.md
+++ b/examples/next-uploader-adapter/README.md
@@ -8,11 +8,10 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://uploadcare.com?ref=github-next-example-readme">Website</a> • 
-  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-next-example-readme">Quick Start</a> • 
-  <a href="https://uploadcare.com/docs?ref=github-next-example-readme">Docs</a> • 
-  <a href="https://uploadcare.com/blog?ref=github-next-example-readme">Blog</a> • 
-  <a href="https://discord.gg/mKWRgRsVz8?ref=github-next-example-readme">Discord</a> •
+  <a href="https://uploadcare.com?ref=github-next-example-readme">Website</a> •
+  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-next-example-readme">Quick Start</a> •
+  <a href="https://uploadcare.com/docs?ref=github-next-example-readme">Docs</a> •
+  <a href="https://uploadcare.com/blog?ref=github-next-example-readme">Blog</a> •
   <a href="https://twitter.com/Uploadcare?ref=github-next-example-readme">Twitter</a>
 </p>
 

--- a/examples/next-uploader/README.md
+++ b/examples/next-uploader/README.md
@@ -8,11 +8,10 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://uploadcare.com?ref=github-next-example-readme">Website</a> • 
-  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-next-example-readme">Quick Start</a> • 
-  <a href="https://uploadcare.com/docs?ref=github-next-example-readme">Docs</a> • 
-  <a href="https://uploadcare.com/blog?ref=github-next-example-readme">Blog</a> • 
-  <a href="https://discord.gg/mKWRgRsVz8?ref=github-next-example-readme">Discord</a> •
+  <a href="https://uploadcare.com?ref=github-next-example-readme">Website</a> •
+  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-next-example-readme">Quick Start</a> •
+  <a href="https://uploadcare.com/docs?ref=github-next-example-readme">Docs</a> •
+  <a href="https://uploadcare.com/blog?ref=github-next-example-readme">Blog</a> •
   <a href="https://twitter.com/Uploadcare?ref=github-next-example-readme">Twitter</a>
 </p>
 

--- a/examples/react-uploader-adapter/README.md
+++ b/examples/react-uploader-adapter/README.md
@@ -8,11 +8,10 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://uploadcare.com?ref=github-react-example-readme">Website</a> • 
-  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-react-example-readme">Quick Start</a> • 
-  <a href="https://uploadcare.com/docs?ref=github-react-example-readme">Docs</a> • 
-  <a href="https://uploadcare.com/blog?ref=github-react-example-readme">Blog</a> • 
-  <a href="https://discord.gg/mKWRgRsVz8?ref=github-react-example-readme">Discord</a> •
+  <a href="https://uploadcare.com?ref=github-react-example-readme">Website</a> •
+  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-react-example-readme">Quick Start</a> •
+  <a href="https://uploadcare.com/docs?ref=github-react-example-readme">Docs</a> •
+  <a href="https://uploadcare.com/blog?ref=github-react-example-readme">Blog</a> •
   <a href="https://twitter.com/Uploadcare?ref=github-react-example-readme">Twitter</a>
 </p>
 
@@ -51,12 +50,12 @@ Please, read the [File Uploader documentation](https://uploadcare.com/docs/file-
 
 File Uploader is native to the Web but not to React. It's easy to use File Uploader in a React app, but note that a part of your solution will encapsulate non-React code.
 
-E.g. in one of the examples we created a [FileUploader](src/components/FileUploader/FileUploader.tsx) component 
+E.g. in one of the examples we created a [FileUploader](src/components/FileUploader/FileUploader.tsx) component
 which provides React-friendly API for the rest of the view. There is a File Uploader inside this component and nowhere else.
 
 ### Styling
 
-If your styling solution may provide class string or style object, feel free to use them on components like 
+If your styling solution may provide class string or style object, feel free to use them on components like
 `uc-file-uploader-regular` and override default class using CSS variables.
 
 Otherwise you may go “full override” way and pass a string with styles to a File Uploader type of your choice.

--- a/examples/react-uploader/README.md
+++ b/examples/react-uploader/README.md
@@ -8,11 +8,10 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://uploadcare.com?ref=github-react-example-readme">Website</a> • 
-  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-react-example-readme">Quick Start</a> • 
-  <a href="https://uploadcare.com/docs?ref=github-react-example-readme">Docs</a> • 
-  <a href="https://uploadcare.com/blog?ref=github-react-example-readme">Blog</a> • 
-  <a href="https://discord.gg/mKWRgRsVz8?ref=github-react-example-readme">Discord</a> •
+  <a href="https://uploadcare.com?ref=github-react-example-readme">Website</a> •
+  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-react-example-readme">Quick Start</a> •
+  <a href="https://uploadcare.com/docs?ref=github-react-example-readme">Docs</a> •
+  <a href="https://uploadcare.com/blog?ref=github-react-example-readme">Blog</a> •
   <a href="https://twitter.com/Uploadcare?ref=github-react-example-readme">Twitter</a>
 </p>
 
@@ -60,7 +59,7 @@ Please, read the [File Uploader documentation](https://uploadcare.com/docs/file-
 
 File Uploader is native to the Web but not to React. It's easy to use File Uploader in a React app, but note that a part of your solution will encapsulate non-React code.
 
-E.g. in one of the examples we created a [FileUploader](src/components/FileUploader/FileUploader.tsx) component 
+E.g. in one of the examples we created a [FileUploader](src/components/FileUploader/FileUploader.tsx) component
 which provides React-friendly API for the rest of the view. There is a File Uploader inside this component and nowhere else.
 
 ### Non-React things you should know about
@@ -72,12 +71,12 @@ which provides React-friendly API for the rest of the view. There is a File Uplo
 
 3. Some attributes required by File Uploader are kebab-cased, not camelCased as usual for React world.
 
-4. You are able to invoke [some methods of File Uploader](https://uploadcare.com/docs/file-uploader/api/) 
+4. You are able to invoke [some methods of File Uploader](https://uploadcare.com/docs/file-uploader/api/)
    to control its behavior.
 
 ### Styling
 
-If your styling solution may provide class string or style object, feel free to use them on components like 
+If your styling solution may provide class string or style object, feel free to use them on components like
 `uc-file-uploader-regular` and override default class using CSS variables.
 
 Otherwise you may go “full override” way and pass a string with styles to a File Uploader type of your choice.

--- a/examples/svelte-uploader/README.md
+++ b/examples/svelte-uploader/README.md
@@ -8,11 +8,10 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://uploadcare.com?ref=github-svelte-example-readme">Website</a> • 
-  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-svelte-example-readme">Quick Start</a> • 
-  <a href="https://uploadcare.com/docs?ref=github-svelte-example-readme">Docs</a> • 
-  <a href="https://uploadcare.com/blog?ref=github-svelte-example-readme">Blog</a> • 
-  <a href="https://discord.gg/mKWRgRsVz8?ref=github-svelte-example-readme">Discord</a> •
+  <a href="https://uploadcare.com?ref=github-svelte-example-readme">Website</a> •
+  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-svelte-example-readme">Quick Start</a> •
+  <a href="https://uploadcare.com/docs?ref=github-svelte-example-readme">Docs</a> •
+  <a href="https://uploadcare.com/blog?ref=github-svelte-example-readme">Blog</a> •
   <a href="https://twitter.com/Uploadcare?ref=github-svelte-example-readme">Twitter</a>
 </p>
 

--- a/examples/vue-uploader/README.md
+++ b/examples/vue-uploader/README.md
@@ -8,11 +8,10 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://uploadcare.com?ref=github-vue-example-readme">Website</a> • 
-  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-vue-example-readme">Quick Start</a> • 
-  <a href="https://uploadcare.com/docs?ref=github-vue-example-readme">Docs</a> • 
-  <a href="https://uploadcare.com/blog?ref=github-vue-example-readme">Blog</a> • 
-  <a href="https://discord.gg/mKWRgRsVz8?ref=github-vue-example-readme">Discord</a> •
+  <a href="https://uploadcare.com?ref=github-vue-example-readme">Website</a> •
+  <a href="https://uploadcare.com/docs/start/quickstart?ref=github-vue-example-readme">Quick Start</a> •
+  <a href="https://uploadcare.com/docs?ref=github-vue-example-readme">Docs</a> •
+  <a href="https://uploadcare.com/blog?ref=github-vue-example-readme">Blog</a> •
   <a href="https://twitter.com/Uploadcare?ref=github-vue-example-readme">Twitter</a>
 </p>
 
@@ -54,13 +53,13 @@ Please, read the [File Uploader documentation](https://uploadcare.com/docs/file-
 ### Vue + Web Components
 
 File Uploader is native to the Web but not to Vue. However, Vue does everything to make solutions based on Web Components
-to work properly with it. 
+to work properly with it.
 
-To help Vue to figure out where you're using Web Components, you have to specify 
-[`compilerOptions.isCustomElement` option](https://vuejs.org/api/application.html#app-config-compileroptions). 
+To help Vue to figure out where you're using Web Components, you have to specify
+[`compilerOptions.isCustomElement` option](https://vuejs.org/api/application.html#app-config-compileroptions).
 In this example we have done it inside [the Vite config file](vite.config.js).
 
-You may like to read [Vue and Web Components](https://vuejs.org/guide/extras/web-components.html) doc, 
+You may like to read [Vue and Web Components](https://vuejs.org/guide/extras/web-components.html) doc,
 if you want to know more about using custom elements in Vue.
 
 ### Options API vs. Composition API
@@ -71,7 +70,7 @@ which provides Vue-friendly API for the rest of the example. There is a File Upl
 However, Vue 3 supports two different API styles: Options API and Composition API. We do not know which one you prefer,
 so we have implemented the example twice.
 
-By default we use Options API because the whole app is built with it. But you're free to switch the `import` path 
+By default we use Options API because the whole app is built with it. But you're free to switch the `import` path
 in [FormView.vue](src/views/FormView/FormView.vue) from [FileUploader.options.vue](src/components/FileUploader/FileUploader.options.vue)
 to [FileUploader.composition.vue](src/components/FileUploader/FileUploader.composition.vue) to ensure that it works too.
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "examples/vue-uploader"
   ],
   "scripts": {
-    "install-deps": "for dir in ./examples/*; do npm install --prefix \"${dir}\"; done",
-    "install-ci-deps": "for dir in ./examples/*; do npm ci --prefix \"${dir}\"; done",
     "build": "for dir in ./examples/*; do npm run build --prefix \"${dir}\"; done"
   },
   "author": "Uploadcare",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the Discord link from the centered top navigation across the project.
  * Normalized centered link formatting and line breaks in multiple example READMEs, removing trailing whitespace for cleaner display and consistent spacing.
  * Minor whitespace fixes elsewhere in READMEs to improve rendering consistency.

* **Chores**
  * Simplified dependency installation workflow and removed legacy workspace install scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->